### PR TITLE
Fix the help for Open-OracleConnection

### DIFF
--- a/SimplySql/Providers/Oracle/config.ps1
+++ b/SimplySql/Providers/Oracle/config.ps1
@@ -15,7 +15,7 @@ Function Open-OracleConnection {
         
         Oracle (Oracle.ManagedDataAccess)
         Oracle Managed Data Access @ http://www.oracle.com/technetwork/topics/dotnet/index-085163.html
-        .NET Provider @ https://www.nuget.org/packages/Oracle.ManagedDataAccess/
+        Provider for .NET @ https://www.nuget.org/packages/Oracle.ManagedDataAccess/
 
     .Parameter ConnectionName
         The name to associate with the newly created connection.


### PR DESCRIPTION
One of the description lines began with a "." - this confuses the help so it counts it all as invalid and ignores it. 

Before the change (note no synopsis):

```
C:\> help Open-OracleConnection

NAME
    Open-OracleConnection

SYNTAX
    Open-OracleConnection [[-DataSource] <string>] [-ServiceName] <string> -Credential <pscredential> [-ConnectionName
    <string>] [-CommandTimeout <int>] [-Port <int>]  [<CommonParameters>]

...
...
```

After (synopsis now shown):

```
C:\> help Open-OracleConnection

NAME
    Open-OracleConnection

SYNOPSIS
    Open a connection to a Oracle Database.


SYNTAX
    Open-OracleConnection [-ConnectionName <String>] [-CommandTimeout <Int32>] [[-DataSource] <String>] [-ServiceName]
    <String> [-Port <Int32>] -Credential <PSCredential> [<CommonParameters>]

...
...
```