### PR TITLE
Update Classes.ps1

### DIFF
--- a/SimplySql/Classes.ps1
+++ b/SimplySql/Classes.ps1
@@ -5,7 +5,7 @@ Class ProviderBase {
     [int]$CommandTimeout = 30
     [System.Data.IDbConnection]$Connection
     [System.Data.IDbTransaction]$Transaction
-    [System.Collections.Generic.Queue[SqlMessage]]$Messages = (New-Object 'System.Collections.Generic.Queue[SqlMessage]')
+    [System.Collections.Generic.Queue[SqlMessage]]$Messages = ([System.Collections.Generic.Queue[SqlMessage]]::new())
 
     ProviderBase() { If($this.GetType().Name -eq "ProviderBase") { Throw [System.InvalidOperationException]::new("ProviderBase must be inherited!") } }
     


### PR DESCRIPTION
Using `New-Object` with the string type specified in the property instantiation for `$Messages` caused errors when working in PowerShell.exe and not in the ISE.
The error avoided is:
```
New-Object : Cannot find type [System.Collections.Generic.Queue[SqlMessage]]: verify that the assembly containing this
type is loaded.
At line:32 char:16
+         return & $origNewObject @psBoundParameters
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidType: (:) [New-Object], PSArgumentException
    + FullyQualifiedErrorId : TypeNotFound,Microsoft.PowerShell.Commands.NewObjectCommand
```

This has only been tested with PowerShell 5.1 on WIndows 10 LTSC, build 1809