### PR TITLE
v2.0.2 - JSON fix

### DIFF
--- a/ModuleManifest/SimplySql.psd1
+++ b/ModuleManifest/SimplySql.psd1
@@ -12,7 +12,7 @@
 RootModule = 'SimplySql.Cmdlets.dll'
 
 # Version number of this module.
-ModuleVersion = '2.0.1.69'
+ModuleVersion = '2.0.2.70'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Tests/mssql.tests.ps1
+++ b/Tests/mssql.tests.ps1
@@ -154,4 +154,10 @@ Describe "MSSQL" {
             } | Should -Not -Throw
         }
     }
+
+    Context "Validations..." {
+        It "Handles JSON as PSObject" {
+            Invoke-SqlScalar "SELECT @json" -Parameters @{json = (1..5 | ConvertTo-Json -Compress)} | Should -Be "[1,2,3,4,5]"
+        }
+    }
 }

--- a/Tests/mysql.tests.ps1
+++ b/Tests/mysql.tests.ps1
@@ -176,6 +176,12 @@ Describe "MySql" {
             } | Should -Not -Throw
         }
     }
+    
+    Context "Validations..." {
+        It "Handles JSON as PSObject" {
+            Invoke-SqlScalar "SELECT @json" -Parameters @{json = (1..5 | ConvertTo-Json -Compress)} | Should -Be "[1,2,3,4,5]"
+        }
+    }
 }
 
 <#

--- a/Tests/oracle.tests.ps1
+++ b/Tests/oracle.tests.ps1
@@ -172,6 +172,12 @@ Describe "Oracle" {
             } | Should -Not -Throw
         }
     }
+
+    Context "Validations..." {
+        It "Handles JSON as PSObject" {
+            Invoke-SqlScalar "SELECT :json FROM dual" -Parameters @{json = (1..5 | ConvertTo-Json -Compress)} | Should -Be "[1,2,3,4,5]"
+        }
+    }
 }
 <#
     requires that the predefined account HR is unlocked and has password hr

--- a/Tests/postgre.tests.ps1
+++ b/Tests/postgre.tests.ps1
@@ -137,4 +137,10 @@ Describe "PostGre" {
             } | Should -Not -Throw
         }
     }
+
+    Context "Validations..." {
+        It "Handles JSON as PSObject" {
+            Invoke-SqlScalar "SELECT @json" -Parameters @{json = (1..5 | ConvertTo-Json -Compress)} | Should -Be "[1,2,3,4,5]"
+        }
+    }
 }

--- a/Tests/sqlite.tests.ps1
+++ b/Tests/sqlite.tests.ps1
@@ -1,6 +1,9 @@
 Describe "SQLite" {
     BeforeEach { Open-SQLiteConnection }
     AfterEach { Show-SqlConnection -all | Close-SqlConnection }
+    AfterAll {
+        Remove-Item "$home\temp.db"        
+    }
     
     It "Test ConnectionString Switch" {
         {
@@ -163,5 +166,9 @@ Describe "SQLite" {
         }
     }
 
-    It "Remove File" { { Remove-Item "$home\temp.db" } | Should -Not -Throw }
+    Context "Validations..." {
+        It "Handles JSON as PSObject" {
+            Invoke-SqlScalar "SELECT @json" -Parameters @{json = (1..5 | ConvertTo-Json -Compress)} | Should -Be "[1,2,3,4,5]"
+        }
+    }
 }

--- a/source/SimplySql.Engine/Dry.vb
+++ b/source/SimplySql.Engine/Dry.vb
@@ -1,4 +1,5 @@
-﻿Imports System.Data.Common
+﻿Imports System.Data
+Imports System.Data.Common
 Imports System.Runtime.CompilerServices
 Module Dry
     <Extension>
@@ -15,6 +16,16 @@ Module Dry
         this.Data.Add("Query", query)
         Try
             this.Data.Add("Parameters", ht)
+        Catch ex As Exception
+            this.Data.Add("ParameterExceptionMessage", ex.Message)
+        End Try
+    End Sub
+
+    <Extension>
+    Sub AddQueryDetails(this As Exception, query As String, sqlParams As IDataParameterCollection)
+        this.Data.Add("Query", query)
+        Try
+            this.Data.Add("Parameters", sqlParams)
         Catch ex As Exception
             this.Data.Add("ParameterExceptionMessage", ex.Message)
         End Try

--- a/source/SimplySql.Engine/ProviderBase.vb
+++ b/source/SimplySql.Engine/ProviderBase.vb
@@ -39,6 +39,7 @@ Public MustInherit Class ProviderBase
     Public MustOverride Sub ChangeDatabase(databaseName As String) Implements ISimplySqlProvider.ChangeDatabase
 
     Public Overridable Function HandleParamValue(x As Object) As Object
+        If TypeOf x Is System.Management.Automation.PSObject Then x = DirectCast(x, System.Management.Automation.PSObject).BaseObject
         Return If(x, DBNull.Value)
     End Function
 #End Region

--- a/source/SimplySql.Engine/SimplySql.Engine.vbproj
+++ b/source/SimplySql.Engine/SimplySql.Engine.vbproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Npgsql" Version="8.0.1" />
     <PackageReference Include="Npgsql.NetTopologySuite" Version="8.0.1" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.220" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
   </ItemGroup>


### PR DESCRIPTION
When using `ConvertTo-Json` Powershell **appears** to return a `string`, but under the covers it is a `PSObject`.   The update checks for this and converts to the `BaseObject` before passing to the SQL Provider as a parameter value.

Also, minor fix for adding SqlParameters to the exception object when an exception is thrown.